### PR TITLE
[STOR-2575] feat: change leaderships more slowly

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The demote rollback action will revert the changes made by the demote action, re
 
 - `--bootstrap-servers`: The list of Kafka brokers to connect to. Required for both actions.
 - `--kafka-path`: The path to the Kafka installation directory. Default: /opt/kafka.
+- `--concurrent-leader-movements`: The number of concurrent leadership movements beetween brokers.
 - `--kafka-heap-opts`: The heap options to use when starting Kafka. Default: -Xmx512M.
 - `--topic-tracker`: The topic tracker to use. Default: `default`.
 - `--log-file`: The path to the log file. Default: kafka_broker_demoter.log.

--- a/kafka_broker_demoter/cli.py
+++ b/kafka_broker_demoter/cli.py
@@ -68,6 +68,13 @@ def parseargs():
         ),
     )
     parser.add_argument(
+        "--concurrent-leader-movements",
+        type=int,
+        help="The max nº of leader movements that will be carried out at the same time.",
+        default=1,
+        required=False,
+    )
+    parser.add_argument(
         "--kafka-path",
         type=str,
         default="/opt/kafka",
@@ -119,9 +126,9 @@ def main():
     )
 
     if args.demotion_action == "demote":
-        demoter.demote(args.broker_id, args.throttle_bytes)
+        demoter.demote(args.broker_id, args.throttle_bytes, args.concurrent_leader_movements)
     elif args.demotion_action == "demote_rollback":
-        demoter.demote_rollback(args.broker_id, args.remove_throttle)
+        demoter.demote_rollback(args.broker_id, args.remove_throttle, args.concurrent_leader_movements)
     elif args.demotion_action == "update_throttle":
         # Convert broker_ids to a list of integers
         if args.broker_ids:

--- a/kafka_broker_demoter/demoter.py
+++ b/kafka_broker_demoter/demoter.py
@@ -46,7 +46,6 @@ class Demoter(object):
         )
         self.admin_config_tmp_file = self._generate_tmpfile_with_admin_configs()
 
-
     @property
     def _get_admin_client(self):
         if self.admin_client is None:
@@ -95,7 +94,7 @@ class Demoter(object):
             logger.warning("Failed to produce message: {}, trying again...".format(e))
             raise ProduceRecordError
 
-        # Make sure record was saved, agregar si no itienen ack=all
+        # Make sure record was saved
         self._consume_latest_record_per_key(key)
 
         logger.debug(
@@ -815,7 +814,7 @@ class Demoter(object):
 
         """
         # Split entry items into groups of N=concurrent_leader_movements
-        grouped_entries = [demoting_plan["partitions"][i:i+concurrent_leader_movements] for i in range(0, len(demoting_plan["partitions"]), concurrent_leader_movements)]
+        grouped_entries = [demoting_plan["partitions"][i:i + concurrent_leader_movements] for i in range(0, len(demoting_plan["partitions"]), concurrent_leader_movements)]
 
         # Iterate over each group
         for group in grouped_entries:

--- a/kafka_broker_demoter/demoter.py
+++ b/kafka_broker_demoter/demoter.py
@@ -7,6 +7,7 @@ import re
 import string
 import subprocess
 import tempfile
+import time
 
 from kafka import KafkaAdminClient, KafkaConsumer, KafkaProducer
 from kafka.admin import NewTopic
@@ -40,10 +41,11 @@ class Demoter(object):
 
         self.admin_client = None
         self.partitions_temp_filepath = None
-        self.admin_config_tmp_file = None
         self.admin_config_content = (
             "default.api.timeout.ms=240000\nrequest.timeout.ms=120000"
         )
+        self.admin_config_tmp_file = self._generate_tmpfile_with_admin_configs()
+
 
     @property
     def _get_admin_client(self):
@@ -93,7 +95,7 @@ class Demoter(object):
             logger.warning("Failed to produce message: {}, trying again...".format(e))
             raise ProduceRecordError
 
-        # Make sure record was saved
+        # Make sure record was saved, agregar si no itienen ack=all
         self._consume_latest_record_per_key(key)
 
         logger.debug(
@@ -264,7 +266,7 @@ class Demoter(object):
                 new_topics=[topic], validate_only=False
             )
 
-    def demote(self, broker_id, throttle):
+    def demote(self, broker_id, throttle, num_concurrent_leader_movements):
         """
         Demotes a broker by reassigning the partition leaders from the specified broker to other brokers.
         If an ongoing or unfinished demote operation is found for the broker, a BrokerStatusError is raised.
@@ -309,7 +311,8 @@ class Demoter(object):
                 )
             )
             self._change_replica_assignment(demoted_partitions_state)
-            self._trigger_leader_election(demoted_partitions_state)
+            self._trigger_leader_election(demoted_partitions_state, num_concurrent_leader_movements)
+
             self._save_rollback_plan(broker_id, current_partitions_state)
             if throttle > 0:
                 self._set_throttles(broker_id, throttle)
@@ -691,7 +694,7 @@ class Demoter(object):
 
         print(json.dumps(broker_configs))
 
-    def demote_rollback(self, broker_id, remove_throttle):
+    def demote_rollback(self, broker_id, remove_throttle, num_concurrent_leader_movements):
         """
         Perform a rollback for the previous demote operation on a specific broker.
 
@@ -717,7 +720,7 @@ class Demoter(object):
             )
         )
         self._change_replica_assignment(previous_partitions_state)
-        self._trigger_leader_election(previous_partitions_state)
+        self._trigger_leader_election(previous_partitions_state, num_concurrent_leader_movements)
         self._produce_record(broker_id, None)
         if remove_throttle:
             self._unset_throttles(broker_id)
@@ -739,22 +742,20 @@ class Demoter(object):
             None.
 
         Notes:
-            - If `self.partitions_temp_filepath` is already set, a new temporary file will not be generated.
             - The generated filepath will have a random filename consisting of lowercase letters and digits.
             - The generated filepath will have the '.json' extension.
 
         """
-        if self.partitions_temp_filepath is None:
-            filename = "".join(
-                random.choices(string.ascii_lowercase + string.digits, k=10)
-            )
-            self.partitions_temp_filepath = tempfile.mktemp(
-                suffix=".json", prefix=filename
-            )
+        filename = "".join(
+            random.choices(string.ascii_lowercase + string.digits, k=10)
+        )
+        partitions_temp_filepath = tempfile.mktemp(
+            suffix=".json", prefix=filename
+        )
 
-        with open(self.partitions_temp_filepath, "w") as temp_file:
+        with open(partitions_temp_filepath, "w") as temp_file:
             json.dump(data, temp_file)
-            return self.partitions_temp_filepath
+            return partitions_temp_filepath
 
     def _change_replica_assignment(self, demoting_plan):
         """
@@ -783,49 +784,57 @@ class Demoter(object):
     def _generate_tmpfile_with_admin_configs(self):
         """
         Generate a temporary file containing the admin configurations.
-
-        If the temporary file doesn't already exist, it will be created. The admin configurations
-        are written to the file, and the file is closed before returning its name.
+        The admin configurations are written to the file, and the file
+        is closed before returning its name.
 
         Returns:
             str: The path/name of the temporary file.
 
         """
-        if self.admin_config_tmp_file is None:
-            self.admin_config_tmp_file = tempfile.NamedTemporaryFile(delete=False)
+        self.admin_config_tmp_file = tempfile.NamedTemporaryFile(delete=False)
 
         self.admin_config_tmp_file.write(self.admin_config_content.encode())
         self.admin_config_tmp_file.close()
         return self.admin_config_tmp_file.name
 
-    def _trigger_leader_election(self, demoting_plan):
+    def _trigger_leader_election(self, demoting_plan, concurrent_leader_movements):
         """
         Trigger a leader election using the demoting plan.
 
         This method runs the `kafka-leader-election.sh` script with the provided demoting plan.
         The command is executed using the provided Kafka installation's path, the generated admin
         configurations, the bootstrap servers, and the path to the temporary file containing
-        the demoting plan in JSON format.
+        the demoting plan in JSON format. The number of leadership movements is limited to concurrent_leader_movements
+        to avoid stressing the brokers.
 
         Args:
             demoting_plan (dict or list): A dictionary or list representation of the demoting plan.
-
+            concurrent_leader_movements (int): Nº of concurrent leader movements between brokers.
         Raises:
             TriggerLeaderElectionError: If the leader election fails.
 
         """
-        demoting_plan_filepath = self._generate_tempfile_with_json_content(
-            demoting_plan
-        )
-        command = "{}/bin/kafka-leader-election.sh --admin.config {} --bootstrap-server {} --election-type PREFERRED --path-to-json-file {}".format(
-            self.kafka_path,
-            self._generate_tmpfile_with_admin_configs(),
-            self.bootstrap_servers,
-            demoting_plan_filepath,
-        )
-        env_vars = os.environ.copy()
-        env_vars["KAFKA_HEAP_OPTS"] = self.kafka_heap_opts
-        self._execute_subprocess(command, env_vars)
+
+        # Split entry items into groups of N=concurrent_leader_movements
+        grouped_entries = [demoting_plan["partitions"][i:i+concurrent_leader_movements] for i in range(0, len(demoting_plan["partitions"]), concurrent_leader_movements)]
+
+        # Iterate over each group
+        for group in grouped_entries:
+            logger.info("Running kafka-leader-election on partitions: {}".format(group)) 
+            demoting_plan_filepath = self._generate_tempfile_with_json_content(
+                {"partitions": group}
+            )
+            
+            command = "{}/bin/kafka-leader-election.sh --admin.config {} --bootstrap-server {} --election-type PREFERRED --path-to-json-file {}".format(
+                self.kafka_path,
+                self.admin_config_tmp_file,
+                self.bootstrap_servers,
+                demoting_plan_filepath,
+            )
+            env_vars = os.environ.copy()
+            env_vars["KAFKA_HEAP_OPTS"] = self.kafka_heap_opts
+            self._execute_subprocess(command, env_vars)
+            time.sleep(1)
 
     def _save_rollback_plan(self, broker_id, current_partitions_state):
         logger.info("Saving rollback plan for broker {}".format(broker_id))

--- a/kafka_broker_demoter/demoter.py
+++ b/kafka_broker_demoter/demoter.py
@@ -818,11 +818,11 @@ class Demoter(object):
 
         # Iterate over each group
         for group in grouped_entries:
-            logger.info("Running kafka-leader-election on partitions: {}".format(group)) 
+            logger.info("Running kafka-leader-election on partitions: {}".format(group))
             demoting_plan_filepath = self._generate_tempfile_with_json_content(
                 {"partitions": group}
             )
-            
+
             command = "{}/bin/kafka-leader-election.sh --admin.config {} --bootstrap-server {} --election-type PREFERRED --path-to-json-file {}".format(
                 self.kafka_path,
                 self.admin_config_tmp_file,

--- a/kafka_broker_demoter/demoter.py
+++ b/kafka_broker_demoter/demoter.py
@@ -752,7 +752,7 @@ class Demoter(object):
         partitions_temp_filepath = tempfile.mktemp(
             suffix=".json", prefix=filename
         )
-
+        self.partitions_temp_filepath = partitions_temp_filepath
         with open(partitions_temp_filepath, "w") as temp_file:
             json.dump(data, temp_file)
             return partitions_temp_filepath
@@ -791,11 +791,11 @@ class Demoter(object):
             str: The path/name of the temporary file.
 
         """
-        self.admin_config_tmp_file = tempfile.NamedTemporaryFile(delete=False)
+        admin_config_tmp_file = tempfile.NamedTemporaryFile(delete=False)
 
-        self.admin_config_tmp_file.write(self.admin_config_content.encode())
-        self.admin_config_tmp_file.close()
-        return self.admin_config_tmp_file.name
+        admin_config_tmp_file.write(self.admin_config_content.encode())
+        admin_config_tmp_file.close()
+        return admin_config_tmp_file.name
 
     def _trigger_leader_election(self, demoting_plan, concurrent_leader_movements):
         """
@@ -814,7 +814,6 @@ class Demoter(object):
             TriggerLeaderElectionError: If the leader election fails.
 
         """
-
         # Split entry items into groups of N=concurrent_leader_movements
         grouped_entries = [demoting_plan["partitions"][i:i+concurrent_leader_movements] for i in range(0, len(demoting_plan["partitions"]), concurrent_leader_movements)]
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ __location__ = os.path.join(
     os.getcwd(), os.path.dirname(inspect.getfile(inspect.currentframe()))
 )
 
-version = "2.0.6"
+version = "2.1.0"
 
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()

--- a/tests/run
+++ b/tests/run
@@ -11,7 +11,7 @@ echo "Installing test libs..."
 pip3 install -r requirements/test_requirements.txt
  
 echo "Running Flake8 tests..."
-flake8 --ignore=E501,W503 kafka_broker_demoter tests 
+flake8 --ignore=E501,W503 kafka_broker_demoter tests
 
 echo "Running isort check..."
 isort --profile black -c kafka_broker_demoter tests

--- a/tests/units/test_kafka_broker_demoter.py
+++ b/tests/units/test_kafka_broker_demoter.py
@@ -295,10 +295,7 @@ class TestDemoter(unittest.TestCase):
         kafka_path = "/path/to/kafka"
         bootstrap_servers = "localhost:9092"
         kafka_heap_opts = "-Xmx1G"
-        demoting_plan = {"partitions":
-                            [{"topic": "foo", "partition": 1},
-                            {"topic": "foobar", "partition": 2}]
-                        }
+        demoting_plan = {"partitions": [{"topic": "foo", "partition": 1}, {"topic": "foobar", "partition": 2}]}
         concurrent_leader_movements = 1
 
         # Mock subprocess.run() method behavior

--- a/tests/units/test_kafka_broker_demoter.py
+++ b/tests/units/test_kafka_broker_demoter.py
@@ -288,9 +288,10 @@ class TestDemoter(unittest.TestCase):
             env=expected_env_vars,
         )
 
+    @patch("time.sleep")
     @patch("subprocess.run")
     @patch("os.environ.copy")
-    def test_trigger_leader_election(self, mock_environ_copy, mock_subprocess_run):
+    def test_trigger_leader_election(self, mock_environ_copy, mock_subprocess_run, mock_sleep):
         kafka_path = "/path/to/kafka"
         bootstrap_servers = "localhost:9092"
         kafka_heap_opts = "-Xmx1G"
@@ -337,9 +338,10 @@ class TestDemoter(unittest.TestCase):
         # This assertion looks that we are throttling the nº of concurrent leadership movements
         assert mock_subprocess_run.call_count == len(demoting_plan["partitions"]) / concurrent_leader_movements
 
+    @patch("time.sleep")
     @patch("subprocess.run")
     @patch("os.environ.copy")
-    def test_concurrent_leader_movement_bigger_than_partitions_of_plan(self, mock_environ_copy, mock_subprocess_run):
+    def test_concurrent_leader_movement_bigger_than_partitions_of_plan(self, mock_environ_copy, mock_subprocess_run, mock_sleep):
         kafka_path = "/path/to/kafka"
         bootstrap_servers = "localhost:9092"
         kafka_heap_opts = "-Xmx1G"


### PR DESCRIPTION
After using the demoter on a heavy workload Kafka cluster, we realized that changing all leadership at the same time was causing a big impact on the brokers. To avoid this, we are adding the --concurrent-leader-movements parameter to limit the max nº of leadership movements being done at the same time.

